### PR TITLE
Update decorators to fit the modified meta

### DIFF
--- a/config/components.json
+++ b/config/components.json
@@ -3,25 +3,24 @@
     "theme": "default",
     "keyBinding": "sublime",
     "autoSaveInterval": "2000",
-    "defaultSyntax": "java",
+    "defaultSyntax": "Java",
     "syntaxToModeMap": {
-      "java": {
-        "name": "java"
-      },
-      "C++": {
-        "name": "text/x-c++src",
-        "useCPP": true
-      },
-      "JSON": {
-        "name": "application/json"
-      },
-      "Python": {
-        "name": "text/x-python"
+      "Java": {
+        "name": "text/x-java"
       }
     },
     "attrToSyntaxMap": {
-      "TransitionMethod": {
-        "Method Body": "java"
+      "EnforceableTransition": {
+        "transitionMethod": "Java"
+      },
+      "internal": {
+        "transitionMethod": "Java"
+      },
+      "SpontaneousTransition": {
+        "transitionMethod": "Java"
+      },
+      "Guard": {
+        "guardMethod": "Java"
       }
     }
   }

--- a/src/decorators/BIPComponentTypeDecorator/DiagramDesigner/BIPComponentTypeDecorator.DiagramDesignerWidget.js
+++ b/src/decorators/BIPComponentTypeDecorator/DiagramDesigner/BIPComponentTypeDecorator.DiagramDesignerWidget.js
@@ -38,7 +38,7 @@ define([
         CONN_END_X_MARGIN = 1;
 
     nodePropertyNames = JSON.parse(JSON.stringify(nodePropertyNames));
-    nodePropertyNames.Attributes.cardinality = 'Cardinality';
+    nodePropertyNames.Attributes.cardinality = 'cardinality';
 
     BIPComponentTypeDecorator = function (options) {
         var opts = _.extend({}, options);

--- a/src/decorators/BIPConnectorEndDecorator/DiagramDesigner/BIPConnectorEndDecorator.DiagramDesignerWidget.js
+++ b/src/decorators/BIPConnectorEndDecorator/DiagramDesigner/BIPConnectorEndDecorator.DiagramDesignerWidget.js
@@ -24,8 +24,8 @@ define([
         DECORATOR_ID = 'BIPConnectorEndDecorator';
 
     nodePropertyNames = JSON.parse(JSON.stringify(nodePropertyNames));
-    nodePropertyNames.Attributes.degree = 'Degree';
-    nodePropertyNames.Attributes.multiplicity = 'Multiplicity';
+    nodePropertyNames.Attributes.degree = 'degree';
+    nodePropertyNames.Attributes.multiplicity = 'multiplicity';
 
     BIPConnectorEndDecorator = function (options) {
         var opts = _.extend({}, options);


### PR DESCRIPTION
I have not updated the seed in this branch. I suggest you resolve the meta-violations and check it into the master branch. You might also consider renaming `'internal'` to `'InternalTransition'`.

Btw I noticed a bug in the constraint-checker when running it from the root-node 
[#1337](https://github.com/webgme/webgme/issues/1337). (Also noticed some lacking preciseness in the constraint violation messages.)

In the meanwhile I suggest running the checker for each subtree from the root.

